### PR TITLE
build(autoware_tensorrt_vad): change name for eigen3

### DIFF
--- a/autoware_tensorrt_vad/package.xml
+++ b/autoware_tensorrt_vad/package.xml
@@ -12,9 +12,9 @@
   <!-- ROS2 core dependencies -->
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
-  <depend>eigen3</depend>
   <depend>eigen3_cmake_module</depend>
   <depend>geometry_msgs</depend>
+  <depend>libeigen3-dev</depend>
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rosbag2_cpp</depend>


### PR DESCRIPTION
## Description

- This change updates Eigen3 dependency declarations to follow ROS2 best practices and ensure compatibility with actual Ubuntu package names.
- The official eigen3_cmake_module documentation recommends using `eigen` as build_depend, but the actual Ubuntu package name is `libeigen3-dev`.
- This change aligns with real-world ROS2 project implementations and resolves potential build issues on Ubuntu systems.

**References:**
- [ROS2 eigen3_cmake_module official documentation](https://github.com/ros2/eigen3_cmake_module)
- [ROS2 package dependency issues discussion](https://github.com/ros-perception/perception_pcl/issues/475)
- [Ubuntu package naming conventions for Eigen3](https://packages.ubuntu.com/search?keywords=libeigen3-dev)

<details>
<summary>answer from claude4-sonnet</summary>

![image](https://github.com/user-attachments/assets/f2c10402-7608-43ef-b6ad-17872c90544e)

この質問にお答えするために、ROS2パッケージの依存関係とEigenライブラリの命名規則について調べてみます。

調査結果から、`<depend>libeigen3-dev</depend>`が使用される理由について説明いたします。

## `<depend>libeigen3-dev</depend>`が使用される理由

### 1. **ROS2でのEigen3の標準的な使用方法**

ROS2では、Eigenライブラリを使用する際に以下の組み合わせが推奨されています：

```xml
<depend>eigen3_cmake_module</depend>
<depend>libeigen3-dev</depend>
```

これは、あなたのpackage.xmlでも確認できます：

```15:17:autoware_tensorrt_vad/package.xml
  <depend>eigen3_cmake_module</depend>
  <depend>geometry_msgs</depend>
  <depend>libeigen3-dev</depend>
```

### 2. **`eigen3`と`libeigen3-dev`の違い**

- **`eigen3`**: これは抽象的なパッケージ名で、ROS2のパッケージシステムでは直接解決できません
- **`libeigen3-dev`**: これはUbuntuのaptパッケージ名で、実際にEigenライブラリのヘッダーファイルとCMakeファイルを提供します

### 3. **`eigen3_cmake_module`の役割**

`eigen3_cmake_module`は、Eigenライブラリの検出と設定を標準化するためのCMakeモジュールです。これにより：

- 異なるUbuntuバージョン間でのEigenライブラリの違いを吸収
- 標準的なCMake変数（`Eigen3_INCLUDE_DIRS`など）を設定
- `ament_target_dependencies()`での使用を可能にする

### 4. **パッケージ依存関係の問題**

調査で見つかったGitHubの議論によると、ROS2のパッケージビルドシステム（bloom）では、`build_export_depend`が実行時依存関係として扱われるため、開発用パッケージ（`-dev`）が実行時にも必要とされてしまう問題があります。これは現在のROS2の制限事項です。

### 5. **正しい使用方法**

ROS2でEigenを使用する場合の推奨パターン：

```xml
<!-- CMakeモジュール -->
<buildtool_depend>eigen3_cmake_module</buildtool_depend>
<!-- 実際のライブラリ -->
<depend>libeigen3-dev</depend>
```

そして、CMakeLists.txtでは：

```cmake
find_package(eigen3_cmake_module REQUIRED)
find_package(Eigen3 REQUIRED)
```

このように、`<depend>eigen3</depend>`ではなく`<depend>libeigen3-dev</depend>`を使用するのは、ROS2のパッケージシステムとUbuntuのパッケージシステムの統合における標準的な方法なのです。

![image](https://github.com/user-attachments/assets/3a71f457-05f1-4112-a3ae-8aa3a8ba61ba)

調査結果の根拠となるソースへのリンクをご提供いたします。

## 根拠となるソース

### 1. **ROS2公式のeigen3_cmake_moduleリポジトリ**
- **URL**: https://github.com/ros2/eigen3_cmake_module
- **内容**: ROS2でのEigen使用方法の公式ドキュメント
- **重要な部分**: READMEで推奨される依存関係の書き方

### 2. **ROS2パッケージでの依存関係問題に関するGitHub Issue**
- **URL**: https://github.com/ros-perception/perception_pcl/issues/475
- **タイトル**: "dev dependencies listed as deps in released deb packages"
- **内容**: `libeigen3-dev`が実行時依存関係として扱われる問題についての議論

### 3. **bloom（ROS2パッケージビルドツール）のソースコード**
- **URL**: https://github.com/ros-infrastructure/bloom/blob/b42a1dd043d0712bca7e37dad91c4a54752024d8/bloom/generators/debian/generator.py#L349-L372
- **内容**: `build_export_depend`が実行時依存関係として扱われる実装

### 4. **catkin_pkgでのrun_dependsの定義**
- **URL**: https://github.com/ros-infrastructure/catkin_pkg/blob/eec17e72cbe3c25173ec0cc8868106904397c560/src/catkin_pkg/package.py#L118-L122
- **内容**: `run_depends`が`exec_depends + build_export_depends`として定義されている実装

### 5. **ROS Wiki - package.xmlフォーマットの説明**
- **URL**: https://wiki.ros.org/catkin/package.xml
- **内容**: package.xmlのフォーマット1と2の違い、依存関係タグの説明

### 6. **ROS Discourse - パッケージ分離に関する議論**
- **URL1**: https://discourse.ros.org/t/generating-dev-and-runtime-artefacts-from-ros-packages/12448
- **URL2**: https://discourse.ros.org/t/package-separation-for-building-and-running-ros-applications/35527
- **内容**: ROS2パッケージの開発用と実行用の分離に関する議論

![image](https://github.com/user-attachments/assets/dbfa21a4-1eb4-475e-9da4-d1cfcc3611ec)

おっしゃる通りです。[ROS2公式のeigen3_cmake_moduleリポジトリ](https://github.com/ros2/eigen3_cmake_module)のREADMEには、以下のように記載されています：

```xml
<buildtool_depend>eigen3_cmake_module</buildtool_depend>
<build_depend>eigen</build_depend>
```

しかし、あなたのプロジェクトでは：

```xml
<depend>eigen3_cmake_module</depend>
<depend>libeigen3-dev</depend>
```

となっています。この違いについて説明いたします。

## 公式ドキュメントと実際の使用の違い

### 1. **`eigen` vs `libeigen3-dev`の問題**

公式ドキュメントでは`<build_depend>eigen</build_depend>`と記載されていますが、実際のUbuntuシステムでは：

- `eigen`というパッケージ名は存在しない場合が多い
- 実際のaptパッケージ名は`libeigen3-dev`

### 2. **`buildtool_depend` vs `depend`の違い**

- **`buildtool_depend`**: ビルド時のツール依存関係（CMakeモジュールなど）
- **`depend`**: ビルド時と実行時の両方で必要な依存関係

### 3. **実際のプロジェクトでの使用パターン**

多くの実際のROS2プロジェクトでは、以下のパターンが使用されています：

```xml
<depend>eigen3_cmake_module</depend>
<depend>libeigen3-dev</depend>
```

これは、実際のシステム環境での互換性を考慮した結果です。

### 4. **なぜこの違いが生じるのか**

1. **公式ドキュメントの抽象化**: 公式ドキュメントは理想的な形を示している
2. **実際のシステム制約**: Ubuntu/Debianの実際のパッケージ名に合わせる必要がある
3. **ROS2ディストリビューションの違い**: 異なるROS2バージョンでの互換性

### 5. **推奨される実際の使用方法**

実際のプロジェクトでは、あなたが使用している形式が正しいです：

```xml
<depend>eigen3_cmake_module</depend>
<depend>libeigen3-dev</depend>
```

これにより、実際のUbuntuシステムでのビルドが確実に動作します。

公式ドキュメントは理想的な形を示していますが、実際の開発では環境に応じた調整が必要になることがよくあります。あなたのプロジェクトの設定は、実用的で正しいアプローチです。


</details>

## Related links

None.

## How was this PR tested?

```bash
❯ colcon build --symlink-install --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Release --packages-up-to autoware_tensorrt_vad
Starting >>> autoware_tensorrt_vad
Finished <<< autoware_tensorrt_vad [6.03s]                  

Summary: 1 package finished [6.16s]
```

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
