### PR TITLE
build(autoware_tensorrt_vad): add autoware_msgs to repos for build depends

### DIFF
--- a/build_depends_humble.repos
+++ b/build_depends_humble.repos
@@ -1,5 +1,9 @@
 repositories:
   # core
+  core/autoware_msgs:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_msgs.git
+    version: 1.7.0
   core/autoware_cmake:
     type: git
     url: https://github.com/autowarefoundation/autoware_cmake.git


### PR DESCRIPTION
## Description

- Update `build_depends_humble.repos` to prepare for adding `build-and-test` to CI.

## Related links

None

## How was this PR tested?

We do not have to test this PR now. This does not influence today's codebase.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
