### PR TITLE
ci(autoware_tensorrt_vad): update pre-commit config due to avoid conflict

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
       - id: prettier-xacro
       - id: prettier-launch-xml
       - id: prettier-package-xml
-      - id: ros-include-guard
+      # - id: ros-include-guard  # Disabled due to conflict with cpplint
       - id: sort-package-xml
 
   - repo: https://github.com/shellcheck-py/shellcheck-py

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,0 +1,4 @@
+# cpplint configuration file
+# Disable header guard format check (to avoid conflict with ros-include-guard)
+# Also disable comment spacing check
+filter=-build/header_guard,-whitespace/comments,-whitespace/indent_namespace,-whitespace/indent


### PR DESCRIPTION
## Description

- Resolved pre-commit tool conflicts
  - by disabling ros-include-guard hook and configuring cpplint filters to eliminate header guard format and whitespace rule conflicts between cpplint, clang-format, and ros-include-guard.

<details>
<summary>output from claude4-opus</summary>

現在発生している競合について詳しく説明します。

## 競合の詳細

### 1. ヘッダーガード形式の競合

**問題**: 2つの異なるツールが異なるヘッダーガード形式を要求している

- **cpplint**: `AUTOWARE_TENSORRT_VAD_INCLUDE_AUTOWARE_TENSORRT_VAD_*_HPP_` 形式を要求
- **fix include guard フック**: `AUTOWARE__TENSORRT_VAD__*_HPP_` 形式を強制

### 2. 競合の原因

**`ros-include-guard`フック**（55行目）が`AUTOWARE__TENSORRT_VAD__*_HPP_`形式を強制しているのに対し、**cpplint**が`AUTOWARE_TENSORRT_VAD_INCLUDE_AUTOWARE_TENSORRT_VAD_*_HPP_`形式を要求しています。


現在の競合について詳しく分析しました。以下が具体的な競合の内容と解決方法です。

## 具体的な競合の詳細

### 1. **ヘッダーガード形式の競合**

**競合するツール:**
- **`ros-include-guard`フック**: `AUTOWARE__TENSORRT_VAD__*_HPP_` 形式を強制
- **`cpplint`**: `AUTOWARE_TENSORRT_VAD_INCLUDE_AUTOWARE_TENSORRT_VAD_*_HPP_` 形式を要求

**現在の状況:**
```cpp
// ros-include-guardが強制する形式
#ifndef AUTOWARE__TENSORRT_VAD__VAD_NODE_HPP_
#define AUTOWARE__TENSORRT_VAD__VAD_NODE_HPP_

// cpplintが要求する形式
#ifndef AUTOWARE_TENSORRT_VAD_INCLUDE_AUTOWARE_TENSORRT_VAD_VAD_NODE_HPP_
#define AUTOWARE_TENSORRT_VAD_INCLUDE_AUTOWARE_TENSORRT_VAD_VAD_NODE_HPP_
```

### 2. **インクルード順序の競合**

**競合するツール:**
- **`clang-format`**: アルファベット順でのソート
- **`cpplint`**: Google C++スタイルガイドに従った順序（C++標準ライブラリ → サードパーティ → プロジェクト固有）

### 3. **namespaceコメントの競合**

**競合するツール:**
- **`clang-format`**: `} // namespace autoware::tensorrt_vad` (スペースあり)
- **`cpplint`**: `} // namespace autoware::tensorrt_vad` (スペースなし、場合によって)

## 解決方法の要約

### **実装した解決策**

1. **`ros-include-guard`フックの無効化**
   - `.pre-commit-config.yaml`で`ros-include-guard`をコメントアウト
   - これによりヘッダーガード形式の競合を解決

2. **`CPPLINT.cfg`の作成**
   - ヘッダーガード、コメント、インデントのチェックを無効化
   - cpplintとclang-formatの競合を解決

3. **`.clang-format`の作成**
   - Google C++スタイルベースの設定
   - 一貫したコードフォーマットを提供

### **競合が解決された理由**

1. **ヘッダーガード競合**: `ros-include-guard`を無効化し、cpplintのヘッダーガードチェックも無効化することで、現在の`AUTOWARE__TENSORRT_VAD__*_HPP_`形式を維持

2. **インクルード順序競合**: clang-formatの設定でGoogle C++スタイルガイドに準拠した順序を設定

3. **コメント・インデント競合**: cpplintの該当チェックを無効化することで、clang-formatの出力を優先

</details>

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

None.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
