### PR TITLE
chore(autoware_tensorrt_vad): update .gitignore not to track .vscode and cyclonedds.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,8 +49,14 @@ qtcreator-*
 # Emacs
 .#*
 
+# VSCode
+.vscode/
+
 # Catkin custom files
 CATKIN_IGNORE
+
+# ROS 2 log
+cyclonedds.log
 
 #prettier
 node_modules/


### PR DESCRIPTION
## Description

- Add `.vscode` and `cyclonedds.log` in `.gitignore`.

## Related links

None.

## How was this PR tested?

- I checked this PR by running `git status` and I found that `.vscode` and `cyclonedds.log` are not tracked.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
