### PR TITLE
ci(autoware_tensorrt_vad): remove clang-tidy from pre-commit

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,54 @@
+---
+# This file is automatically synced from:
+# https://github.com/autowarefoundation/sync-file-templates
+# To make changes, update the source repository and follow the guidelines
+# in its README.
+
+# Modified from https://github.com/ament/ament_lint/blob/master/
+# ament_clang_format/ament_clang_format/configuration/.clang-format
+Language: Cpp
+BasedOnStyle: Google
+
+AccessModifierOffset: -2
+AlignAfterOpenBracket: AlwaysBreak
+AllowShortFunctionsOnASingleLine: InlineOnly
+BraceWrapping:
+  AfterClass: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterStruct: true
+BreakBeforeBraces: Custom
+ColumnLimit: 200
+ConstructorInitializerIndentWidth: 0
+ContinuationIndentWidth: 2
+DerivePointerAlignment: false
+PointerAlignment: Middle
+ReflowComments: true
+IncludeCategories:
+  # C++ system headers
+  - Regex: <[a-z_]*>
+    Priority: 6
+    CaseSensitive: true
+  # C system headers
+  - Regex: <.*\.h>
+    Priority: 5
+    CaseSensitive: true
+  # Boost headers
+  - Regex: boost/.*
+    Priority: 4
+    CaseSensitive: true
+  # Message headers
+  - Regex: .*_msgs/.*
+    Priority: 3
+    CaseSensitive: true
+  - Regex: .*_srvs/.*
+    Priority: 3
+    CaseSensitive: true
+  # Other Package headers
+  - Regex: <.*>
+    Priority: 2
+    CaseSensitive: true
+  # Local package headers
+  - Regex: '".*"'
+    Priority: 1
+    CaseSensitive: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,13 +81,13 @@ repos:
       - id: clang-format
         types_or: [c++, c, cuda]
 
-  # Add clang-tidy for naming convention enforcement
-  - repo: https://github.com/pocc/pre-commit-hooks
-    rev: v1.3.5
-    hooks:
-      - id: clang-tidy
-        args: [--config-file=.clang-tidy]
-        types_or: [c++, c]
+  # Add clang-tidy for naming convention enforcement (temporarily disabled)
+  # - repo: https://github.com/pocc/pre-commit-hooks
+  #   rev: v1.3.5
+  #   hooks:
+  #     - id: clang-tidy
+  #       args: [--config-file=.clang-tidy]
+  #       types_or: [c++, c]
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.30.0


### PR DESCRIPTION
## Description

Remove clang-tidy from pre-commit

## Related links

None

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
